### PR TITLE
Remove title customization with content_for

### DIFF
--- a/views/index.slim
+++ b/views/index.slim
@@ -1,9 +1,5 @@
-- content_for :title do
-  | Abagnale Transactions
+h1 Abagnale Transactions
 
-h1
-  | Abagnale Transactions
-  
 table.transactions
   thead
     th Date
@@ -23,5 +19,5 @@ table.transactions
       td.auth_result= tx.auth_result
       td.settled_at== tx.settled_at.nil? ? '&nbsp;' : tx.settled_at.to_s(:db)
       td.refunded_at== tx.refunded_at.nil? ? '&nbsp;' : tx.refunded_at.to_s(:db)
-      
+
 == will_paginate @transactions

--- a/views/layout.slim
+++ b/views/layout.slim
@@ -1,10 +1,9 @@
 doctype html
 html
   head
-    title= yield_content :title
+    title Abagnale
     meta charset="utf-8"
     link rel='stylesheet' type='text/css' href='app.css'
 
   body
     == yield
-  


### PR DESCRIPTION
I do not understand why this now causes an error deep in Sinatra (preventing rendering the index page), but it doesn't seem all that important.